### PR TITLE
automatix/bundlewrap.py: Catch NoSuchNode exception when assigning local python vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ Here you define the commands automatix shall execute.
 4) **python**: Python code to execute. If bundlewrap is enabled, the
  Bundlewrap repository object is avaiable via AUTOMATIX_BW_REPO and 
  system node objects are available via systemname_node.
+ Use `AUTOMATIX_BW_REPO.reload()` to reinitialize the Bundlewrap 
+ repository from file system. This can be useful for using newly
+ created nodes (e.g. remote commands).
 
 **ASSIGNMENT**: For **local**, **remote** and **python** action you
  can also define a variable to which the output will be assigned.

--- a/automatix/__init__.py
+++ b/automatix/__init__.py
@@ -16,10 +16,9 @@ else:
     from .logger import init_logger
 
 if CONFIG.get('bundlewrap'):
-    from bundlewrap.repo import Repository
-    from .bundlewrap import BWCommand
+    from .bundlewrap import BWCommand, AutomatixBwRepo
 
-    CONFIG['bw_repo'] = Repository(repo_path=os.environ.get('BW_REPO_PATH'))
+    CONFIG['bw_repo'] = AutomatixBwRepo(repo_path=os.environ.get('BW_REPO_PATH'))
     cmdClass = BWCommand
 else:
     cmdClass = Command

--- a/automatix/bundlewrap.py
+++ b/automatix/bundlewrap.py
@@ -1,3 +1,5 @@
+from bundlewrap.exceptions import NoSuchNode
+
 from .command import Command
 
 
@@ -5,7 +7,10 @@ class BWCommand(Command):
     def _generate_python_vars(self):
         locale_vars = {'AUTOMATIX_BW_REPO': self.env.config["bw_repo"]}
         for key, value in self.env.systems.items():
-            locale_vars[f'{key}_node'] = self.env.config["bw_repo"].get_node(value)
+            try:
+                locale_vars[f'{key}_node'] = self.env.config["bw_repo"].get_node(value)
+            except NoSuchNode:
+                self.env.LOG.warning(f'bw node "{value}" does not exist, "{key}_node" not set')
         locale_vars['vars'] = self.env.vars
         return locale_vars
 

--- a/automatix/bundlewrap.py
+++ b/automatix/bundlewrap.py
@@ -1,6 +1,12 @@
 from bundlewrap.exceptions import NoSuchNode
+from bundlewrap.repo import Repository
 
 from .command import Command
+
+
+class AutomatixBwRepo(Repository):
+    def reload(self):
+        self.__init__(repo_path=self.path)
 
 
 class BWCommand(Command):


### PR DESCRIPTION
This allows to add nodes to the bw repository and reinitialize it via AUTOMATIX_BW_REPO.__init__(AUTOMATIX_BW_REPO.path). Afterwards the added nodes should be also available via remote@ is defined as system.