### PR TITLE
fix default value for BW_REPO_PATH

### DIFF
--- a/automatix/__init__.py
+++ b/automatix/__init__.py
@@ -25,7 +25,7 @@ def main():
     if CONFIG.get('bundlewrap'):
         from .bundlewrap import BWCommand, AutomatixBwRepo
 
-        CONFIG['bw_repo'] = AutomatixBwRepo(repo_path=os.environ.get('BW_REPO_PATH'))
+        CONFIG['bw_repo'] = AutomatixBwRepo(repo_path=os.environ.get('BW_REPO_PATH', '.'))
         cmdClass = BWCommand
     else:
         cmdClass = Command


### PR DESCRIPTION
If you don't set a default value, `environ.get()` will return `None`, thus bundlewrap will use `/dev/null` as its repo path, which in turn does lead to `bundlewrap.exceptions.NoSuchNode` for every remote action.

We now set the default to '.', which will get bundlewrap to do its own path discovery, possibly leading to this working as the user expects