### PR TITLE
Remove trailing newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,8 @@ Preferred way of using **automatix** is to put often used and complex
 
 Be careful with **assignments** containing line breaks (echo, ...).
  Using the variables may lead to unexpected behaviour or errors.
+ From version 1.14.0 on trailing new lines in **assignments**
+ of Shell commands (_local_, _remote@_) are removed.
 
 Assignments containing **null bytes** are currently not supported.
 

--- a/automatix/command.py
+++ b/automatix/command.py
@@ -288,8 +288,9 @@ class Command:
         if self.assignment_var:
             proc = subprocess.run(cmd, shell=True, executable='/bin/bash', stdout=subprocess.PIPE)
             output = proc.stdout.decode(self.env.config["encoding"])
-            self.env.vars[self.assignment_var] = output
-            self.env.LOG.info(f'Variable {self.assignment_var} = {output}')
+            self.env.vars[self.assignment_var] = assigned_value = output.rstrip('\r\n')
+            hint = ' (trailing newline removed)' if (output.endswith('\n') or output.endswith('\r')) else ''
+            self.env.LOG.info(f'Variable {self.assignment_var} = "{assigned_value}"{hint}')
         else:
             proc = subprocess.run(cmd, shell=True, executable='/bin/bash')
         return proc.returncode


### PR DESCRIPTION
Remove trailing newlines when assinging from Bash command

This is most of the time the desired behaviour.

Bash itself removes trailing newlines when assigning shell variables like `a=$(echo "Hallo")`

If you want the newline, you now have to add it explicitly on insert.