### PR TITLE
Add support for PVARS in the bracket notation

### DIFF
--- a/automatix/automatix.py
+++ b/automatix/automatix.py
@@ -95,7 +95,7 @@ class Automatix:
         print()
         self.env.LOG.info('Commandline Steps:')
         for cmd in command_list:
-            self.env.LOG.info(f"({cmd.index}) [{cmd.orig_key}]: {cmd.get_resolved_value()}")
+            self.env.LOG.info(f"({cmd.index}) [{cmd.orig_key}]: {cmd.get_resolved_value(dummy=True)}")
 
     def _execute_command_list(self, name: str, start_index: int, treat_as_main: bool):
         try:

--- a/automatix/command.py
+++ b/automatix/command.py
@@ -122,6 +122,7 @@ class Command:
 
         variables['CONST'] = ConstantsWrapper(self.env.config['constants'])
         variables['SYSTEMS'] = SystemsWrapper(self.env.systems)
+        variables['PVARS'] = PVARS
         return self.value.format(**variables)
 
     def print_command(self):

--- a/automatix/environment.py
+++ b/automatix/environment.py
@@ -17,6 +17,21 @@ class AttributedDict(dict):
         self[key] = value
 
 
+class AttributedDummyDict(AttributedDict):
+    def __init__(self, name: str, *args):
+        super().__init__(*args)
+        self.__name__ = name
+
+    def __getattr__(self, key: str):
+        return self[key]
+
+    def __getitem__(self, item):
+        try:
+            return super().__getitem__(item)
+        except KeyError:
+            return f'{{{self.__name__}.{item}}}'
+
+
 class PipelineEnvironment:
     def __init__(
             self,

--- a/automatix/environment_test.py
+++ b/automatix/environment_test.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+
+from automatix.environment import AttributedDict, AttributedDummyDict
+
+tc = TestCase()
+
+
+def test__attributed_dict():
+    test_dict = AttributedDict()
+
+    test_dict['a'] = 5
+    assert test_dict.a == 5
+
+    test_dict.b = 'abcde'
+    assert test_dict['b'] == 'abcde'
+
+    with tc.assertRaises(AttributeError):
+        _ = test_dict.not_existent
+
+    with tc.assertRaises(KeyError):
+        _ = test_dict['not_existent']
+
+
+def test__attributed_dummy_dict():
+    test_dict = AttributedDummyDict('DICTNAME')
+
+    test_dict['a'] = 5
+    assert test_dict.a == 5
+
+    test_dict.b = 'abcde'
+    assert test_dict['b'] == 'abcde'
+
+    assert test_dict.not_existent == test_dict['not_existent'] == '{DICTNAME.not_existent}'
+    assert test_dict.__name__ == 'DICTNAME'


### PR DESCRIPTION
This makes it easier to use die variable values from python commands in subsequent shell commands.