### PR TITLE
Fix determination of remote PIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 2.8.1
+- Fix: Determination of PIDs of still running remote commands
+- Fix: Printing of undefined variables
+
 # 2.8.0
 - Fix: Also shell complete relative paths
 - Feature: Show steps for selection if --jump-to/-j is empty

--- a/automatix/command.py
+++ b/automatix/command.py
@@ -488,6 +488,13 @@ class Command:
                 self.env.LOG.notice(
                     'Remote command seems still to be running! Found PIDs: {}'.format(','.join(ps_pids))
                 )
+                if len(ps_pids) > 1:
+                    self.env.LOG.warning(
+                        'WARNING: Normally there should be at most 1 automatix process on the system.'
+                        f' We found {len(ps_pids)} !!! \n\nThis might be a sign,'
+                        ' that PID determination did nasty things and returned the wrong process IDs.'
+                        ' Please double check the PIDs and proceed very carefully!'
+                    )
                 self.env.send_status('user_input_add')
                 answer = input(
                     '[RR] What should I do? '
@@ -514,10 +521,10 @@ class Command:
         self.env.LOG.info('Keystroke interrupt handled.\n')
 
     def get_remote_pids(self, hostname, cmd) -> []:
-        ps_cmd = f"ps axu | grep {quote(cmd)} | grep -v 'grep' | awk '{{print $2}}'"
-        cmd = f'ssh {hostname} {quote(ps_cmd)} 2>&1'
+        ps_cmd = f"ps axu | grep RUNNING_INSIDE_AUTOMATIX | grep -v 'grep' | awk '{{print $2}}'"
+        remote_ps_cmd = f'ssh {hostname} {quote(ps_cmd)} 2>&1'
         pids = subprocess.check_output(
-            cmd,
+            remote_ps_cmd,
             shell=True,
             executable=self.bash_path,
         ).decode(self.env.config["encoding"]).split()

--- a/automatix/command.py
+++ b/automatix/command.py
@@ -126,7 +126,7 @@ class Command:
 
     def print_command(self):
         print()
-        self.env.LOG.notice(f'({self.index}) [{self.orig_key}]: {self.get_resolved_value()}')
+        self.env.LOG.notice(f'({self.index}) [{self.orig_key}]: {self.get_resolved_value(dummy=True)}')
 
     def show_and_change_variables(self):
         print()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='automatix',
-    version='2.8.0',
+    version='2.8.1',
     description='Automation wrapper for bash and python commands',
     keywords=['bash', 'shell', 'command', 'automation', 'process', 'wrapper', 'devops', 'system administration'],
     long_description=long_description,


### PR DESCRIPTION
Since the automatix allows multiline and more complex commands checking the process list for the whole command seems to be a bad idea. Depending on the command the PIDs returned might contain totally wrong and possibly dangerous process IDs.
We now check for the RUNNING_INSIDE_AUTOMATIX variable which is contained in all remote commands. Also there should be only 1 pid with this string. Otherwise we now give a warning.