### PR TITLE
Empty queued input before input statement

### DIFF
--- a/automatix/__init__.py
+++ b/automatix/__init__.py
@@ -16,7 +16,7 @@ from .config import (
     arguments, CONFIG, get_script, LOG, update_script_from_row, collect_vars, SCRIPT_FIELDS, VERSION, init_logger,
     MAGIC_SELECTION_INT
 )
-from .helpers import selector
+from .helpers import selector, empty_queued_input_data
 from .parallel import screen_switch_loop, get_logfile_dir
 from .progress_bar import setup_scroll_area, destroy_scroll_area
 
@@ -174,6 +174,7 @@ def main():
 
     if os.getenv('AUTOMATIX_SHELL'):
         print('You are running Automatix from an interactive shell of an already running Automatix!')
+        empty_queued_input_data()
         answer = input('Do you really want to proceed? Then type "yes" and ENTER.\n')
         if answer != 'yes':
             sys.exit(0)

--- a/automatix/command.py
+++ b/automatix/command.py
@@ -525,7 +525,7 @@ class Command:
         self.env.LOG.info('Keystroke interrupt handled.\n')
 
     def get_remote_pids(self, hostname, cmd) -> []:
-        ps_cmd = f"ps axu | grep RUNNING_INSIDE_AUTOMATIX | grep -v 'grep' | awk '{{print $2}}'"
+        ps_cmd = "ps axu | grep RUNNING_INSIDE_AUTOMATIX | grep -v 'grep' | awk '{print $2}'"
         remote_ps_cmd = f'ssh {hostname} {quote(ps_cmd)} 2>&1'
         pids = subprocess.check_output(
             remote_ps_cmd,

--- a/automatix/command.py
+++ b/automatix/command.py
@@ -7,6 +7,7 @@ from shlex import quote
 from time import time
 
 from .environment import PipelineEnvironment, AttributedDict, AttributedDummyDict
+from .helpers import empty_queued_input_data
 from .progress_bar import draw_progress_bar, block_progress_bar
 
 PERSISTENT_VARS = PVARS = AttributedDict()
@@ -138,6 +139,7 @@ class Command:
         self.env.LOG.info('Example: var1=xyz')
         self.env.LOG.info('Notice: You can only change 1 variable at a time. Repeat if necessary.')
         self.env.LOG.info('To not change anything just press "ENTER".')
+        empty_queued_input_data()
         answer = input('\n')
         try:
             key, value = answer.split('=', maxsplit=1)
@@ -289,6 +291,7 @@ class Command:
         if self.env.config['progress_bar']:
             block_progress_bar(self.progress_portion)
         self.env.send_status('user_input_add')
+        empty_queued_input_data()
         answer = input(question)
         self.env.send_status('user_input_remove')
 
@@ -496,6 +499,7 @@ class Command:
                         ' Please double check the PIDs and proceed very carefully!'
                     )
                 self.env.send_status('user_input_add')
+                empty_queued_input_data()
                 answer = input(
                     '[RR] What should I do? '
                     '(i: send SIGINT (default), t: send SIGTERM, k: send SIGKILL, p: do nothing and proceed) \n\a')

--- a/automatix/command_test.py
+++ b/automatix/command_test.py
@@ -135,7 +135,8 @@ def test__parse_key():
     assert parse_key('is_jira!?python') == ('is_jira!', None, 'python')
 
 
-def test__show_and_change_variables():
+@mock.patch('automatix.command.empty_queued_input_data')
+def test__show_and_change_variables(mock_empty_queued_input_data: mock.MagicMock):
     cmd = Command(cmd={'python': 'pass'}, index=2, pipeline='pipeline', env=deepcopy(environment), position=1)
     assert cmd.env.vars == {
         'a': '{a}',
@@ -161,3 +162,5 @@ def test__show_and_change_variables():
         'cond2': '!dgkls=432',
         'var1': 'xyz',
     }
+
+    mock_empty_queued_input_data.assert_called()

--- a/automatix/config_test.py
+++ b/automatix/config_test.py
@@ -52,6 +52,7 @@ def test__check_deprecated_syntax__vars(caplog):
     check_deprecated_syntax(ckey='python', entry='vars["myvar"] = xyz', script={}, prefix='[pipeline:7]')
     assert '[pipeline:7] Using "vars["myvar"]" does not work any longer. Use "VARS.myvar" instead.' in caplog.text
 
+
 def test__check_deprecated_syntax__a_vars(caplog):
     check_deprecated_syntax(ckey='python', entry='a_vars["myvar"] = xyz', script={}, prefix='[pipeline:7]')
     assert '[pipeline:7] Using "a_vars["myvar"]" is deprecated. Use "VARS.myvar" instead.' in caplog.text

--- a/automatix/helpers.py
+++ b/automatix/helpers.py
@@ -1,6 +1,8 @@
+from sys import stdin
 from typing import List
 
 import yaml
+from termios import tcflush, TCIFLUSH
 
 yaml.warnings({'YAMLLoadWarning': False})
 
@@ -8,6 +10,10 @@ yaml.warnings({'YAMLLoadWarning': False})
 def read_yaml(yamlfile: str) -> dict:
     with open(yamlfile) as file:
         return yaml.load(file.read(), Loader=yaml.SafeLoader)
+
+
+def empty_queued_input_data():
+    tcflush(stdin, TCIFLUSH)
 
 
 def selector(entries: List[tuple], message: str = 'Found multiple entries, please choose:'):
@@ -26,6 +32,7 @@ def selector(entries: List[tuple], message: str = 'Found multiple entries, pleas
                 for index, entry in enumerate(entries)
             ])
             try:
+                empty_queued_input_data()
                 return entries[int(input(f'\n{message} \n{entry_labels}\n\nYour choice:\n'))][0]
             except (ValueError, IndexError):
                 print('Invalid answer! Please try again and type the number of your desired answer.')


### PR DESCRIPTION
In most cases. We do not want remaining data, especially "Enter" presses during commands, to fill in the desired input at manual steps and error handling questions.