### PR TITLE
Replace assertions in config.py

### DIFF
--- a/automatix/bundlewrap.py
+++ b/automatix/bundlewrap.py
@@ -69,8 +69,8 @@ class BWCommand(Command):
 
 class BWNodesWrapper:
     def __init__(self, repo: Repository, systems: dict):
-        self.repo = repo
-        self.systems = systems
+        self._repo = repo
+        self._systems = systems
 
     def __getattr__(self, name):
-        return self.repo.get_node(self.systems[name])
+        return self._repo.get_node(self._systems[name])

--- a/automatix/command.py
+++ b/automatix/command.py
@@ -568,18 +568,18 @@ def parse_key(key) -> tuple[str, ...]:
 
 class SystemsWrapper:
     def __init__(self, systems: dict):
-        self.systems = systems
+        self._systems = systems
 
     def __getattr__(self, name):
-        return self.systems[name].replace('hostname!', '')
+        return self._systems[name].replace('hostname!', '')
 
 
 class ConstantsWrapper:
     def __init__(self, constants: dict):
-        self.constants = constants
+        self._constants = constants
 
     def __getattr__(self, name):
-        return self.constants[name]
+        return self._constants[name]
 
 
 class AbortException(Exception):

--- a/automatix/config.py
+++ b/automatix/config.py
@@ -297,11 +297,11 @@ def validate_script(script: dict):
         sys.exit(1)
 
     # This would collide with the command.SystemsWrapper.
-    if 'systems' in script.get('systems'):
+    if 'systems' in script.get('systems', []):
         raise ValidationError('"systems" is not allowed as name for a system. Please choose a different name.')
 
     # This would collide with the command.ConstantsWrapper.
-    if 'constants' in script.get('constants'):
+    if 'constants' in script.get('constants', []):
         raise ValidationError('"constants" is not allowed as name for a constant. Please choose a different name.')
 
     warn = 0

--- a/automatix/config.py
+++ b/automatix/config.py
@@ -263,25 +263,30 @@ def check_version(version_str: str):
         match = re.match(pattern=r'([><=!~]{0,2})\s*((\d+\.){0,3}\d+)', string=condition.strip())
         operator = match.group(1)
         required_version = _tupelize(match.group(2))
+        check_passed = False
 
         match operator:
             case '==':
-                assert installed_version == required_version
+                check_passed = installed_version == required_version
             case '!=':
-                assert installed_version != required_version
+                check_passed = installed_version != required_version
             case '>=' | '':
-                assert installed_version >= required_version
+                check_passed = installed_version >= required_version
             case '<=':
-                assert installed_version <= required_version
+                check_passed = installed_version <= required_version
             case '>':
-                assert installed_version > required_version
+                check_passed = installed_version > required_version
             case '<':
-                assert installed_version < required_version
+                check_passed = installed_version < required_version
             case '~=':
-                assert installed_version[:len(required_version) - 1] == required_version[:-1]
-                assert installed_version >= required_version
+                check1 = installed_version[:len(required_version) - 1] == required_version[:-1]
+                check2 = installed_version >= required_version
+                check_passed = check1 and check2
             case _:
                 raise SyntaxError(f'Unknown operator "{operator}"')
+
+        if not check_passed:
+            raise VersionError(f'Condition failed: {operator} {required_version} (installed: {installed_version})')
 
 
 def validate_script(script: dict):
@@ -344,4 +349,8 @@ def update_script_from_row(row: dict, script: dict, index: int):
 
 
 class UnknownSecretTypeException(Exception):
+    pass
+
+
+class VersionError(Exception):
     pass

--- a/automatix/config.py
+++ b/automatix/config.py
@@ -297,12 +297,12 @@ def validate_script(script: dict):
         sys.exit(1)
 
     # This would collide with the command.SystemsWrapper.
-    if 'systems' in script.get('systems', []):
-        raise ValidationError('"systems" is not allowed as name for a system. Please choose a different name.')
+    if '_systems' in script.get('systems', []):
+        raise ValidationError('"_systems" is not allowed as name for a system. Please choose a different name.')
 
     # This would collide with the command.ConstantsWrapper.
-    if 'constants' in script.get('constants', []):
-        raise ValidationError('"constants" is not allowed as name for a constant. Please choose a different name.')
+    if '_constants' in script.get('constants', []):
+        raise ValidationError('"_constants" is not allowed as name for a constant. Please choose a different name.')
 
     warn = 0
     for pipeline in ['always', 'pipeline', 'cleanup']:

--- a/automatix/config_test.py
+++ b/automatix/config_test.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-from automatix.config import _overwrite, _tupelize, check_deprecated_syntax, check_version
+from automatix.config import _overwrite, _tupelize, check_deprecated_syntax, check_version, VersionError
 
 tc = TestCase()
 
@@ -74,22 +74,22 @@ def test__check_version__pass():
 
 @patch('automatix.config.VERSION', '2.1.5')
 def test__check_version__fail():
-    with tc.assertRaises(AssertionError):
+    with tc.assertRaises(VersionError):
         check_version('<2.0.0')
 
-    with tc.assertRaises(AssertionError):
+    with tc.assertRaises(VersionError):
         check_version('>1.0, <2')
 
-    with tc.assertRaises(AssertionError):
+    with tc.assertRaises(VersionError):
         check_version('~= 2.2')
 
-    with tc.assertRaises(AssertionError):
+    with tc.assertRaises(VersionError):
         check_version('~= 3.1')
 
-    with tc.assertRaises(AssertionError):
+    with tc.assertRaises(VersionError):
         check_version('~= 3')
 
-    with tc.assertRaises(AssertionError):
+    with tc.assertRaises(VersionError):
         check_version('<=2.1')
 
     with tc.assertRaises(SyntaxError):


### PR DESCRIPTION
As I learned there might be ways to deactivate assertions globally. This is not what we want here, so we replace this with a different error type.