### PR TITLE
Deprecating "imports" and adding "precommands" instead

### DIFF
--- a/FEATURELIST.md
+++ b/FEATURELIST.md
@@ -13,7 +13,7 @@
 - Conditions
 - Process multiple instances (defined in CSV file) sequentially or parallel (via GNU screen)
 
-- Import (source) Bash functions
+- Precommands for shell functions
 - Bundlewrap + Teamvault support
 
 - Shell completion

--- a/README.md
+++ b/README.md
@@ -232,9 +232,10 @@ The **scriptfile** has to contain valid YAML.
     secrets:
       web_user: v6GQag_username
       web_pw: v6GQag_password
-    # Imports for functions you like to use (path may be modified in configuration)
-    imports:
-      - myfunctions.sh
+    # Precommands, which are executed before each shell command in the main pipeline
+    precommands:
+      local: '. myfunctions'
+      remote: '. /tmp/myfunctions'
     # like command pipeline but will be exectuted always beforehand
     always:
       - python: |
@@ -298,12 +299,17 @@ You can refer to these systems in the command pipeline in multiple ways:
  The resolved secret values are accessible in command line via
  {secretname}. *(only if teamvault is enabled)*
 
-**imports** _(list)_
+**imports** _(list)_, deprecated
 : Listed shell files (see **CONFIGURATION** section, _import_path_)
  will be sourced before every local or remote command execution.
  For remote commands, these files are transferred via tar and ssh to
  your home directory on the remote system beforehand and deleted
  afterwards. This is meant to define some functions you may need.
+
+**precommands** _(associative array)_
+: Define a command which is executed before every shell command.
+ You can specify a command for local and remote commands separately.
+ This can be useful to source files with shell functions you want to use.
 
 **always**, **cleanup** _(list of associative arrays)_
 : See **ALWAYS / CLEANUP PIPELINE** section.

--- a/automatix/command.py
+++ b/automatix/command.py
@@ -96,7 +96,7 @@ class Command:
 
     @property
     def precommand(self):
-        return self.env.script.get('precommand', {}).get(self.get_type(), None)
+        return self.env.script.get('precommands', {}).get(self.get_type(), None)
 
     def get_type(self):
         if self.key == 'local':

--- a/automatix/config.py
+++ b/automatix/config.py
@@ -305,6 +305,12 @@ def validate_script(script: dict):
         raise ValidationError('"_constants" is not allowed as name for a constant. Please choose a different name.')
 
     warn = 0
+
+    if script.get('imports'):
+        LOG.warning('Using "imports" is deprecated. '
+                    'Please refactor your script or use the "precommand" feature instead.')
+        warn += 1
+
     for key, value in script.get('vars', {}).items():
         if str(value).startswith('FILE_'):
             LOG.warning(f'[vars:{key}] FILE_ feature was removed in 2.12.0.'

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,3 @@
+testfunction () {
+  echo 'Hi, I am the test function :)'
+}

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -12,7 +12,12 @@ systems:
 vars:
   myvar: huhu
 
+precommands: # only for main pipeline
+  local: . tests/test.sh
+  remote: . /tmp/test.sh
+
 always:  # <-- The always pipeline is executed even if you just want to print the commands!
+  - local: scp meinimportfile {SYSTEMS.testsystem}:/tmp/
   - local: echo 'Print this always :-)'
   - python: |  # <-- For multiline commands you can use YAML multiline strings (reference: https://yaml-multiline.info/)
       from uuid import uuid4
@@ -21,7 +26,8 @@ always:  # <-- The always pipeline is executed even if you just want to print th
       # We save all local variables (here the imports above) for usage in following commands:
       PERSISTENT_VARS.update(locals())
   - python: pprint('{myvar}')  # Test that our pprint import works and the "normal" way the use the vars.
-  - python: pprint(VARS.myvar)  # Alternative (new) way to access the variable in Python commands.
+  - python: pprint(VARS.myvar) # Alternative (new) way to access the variable in Python commands.
+  - local: scp tests/test.sh {SYSTEMS.testsystem}:/tmp/test.sh
 pipeline:
   - python: PVARS.moin = True  # We can also use the PERSISTENT_VARS shortcut PVARS to save variables for later use.
   - PVARS.moin?local: echo 'Moin'  # Instead of an Automatix variable, we can also use PVARS (only shortcut) in conditions.
@@ -33,6 +39,8 @@ pipeline:
   - python: del PERSISTENT_VARS['uuid4']  # Oh we can also delete a variable from PERSISTENT_VARS
   - a=local: uptime  # And we can overwrite them
   - remote@testsystem: whoami  # A remote command
+  - local: testfunction # Function which we sourced in our precommand
+  - remote@testsystem: testfunction # Same as the remote variant
   - cond=python: 'None' # Caution! It looks like a string and it is in YAML, but for Python it is the None value.
   - cond?python: |  # And that's why this condition is not met and will not be executed.
       print(f'Das ging wohl daneben: {SYSTEMS.testsystem}')

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -17,7 +17,6 @@ precommands: # only for main pipeline
   remote: . /tmp/test.sh
 
 always:  # <-- The always pipeline is executed even if you just want to print the commands!
-  - local: scp meinimportfile {SYSTEMS.testsystem}:/tmp/
   - local: echo 'Print this always :-)'
   - python: |  # <-- For multiline commands you can use YAML multiline strings (reference: https://yaml-multiline.info/)
       from uuid import uuid4


### PR DESCRIPTION
The implementation of the imports feature is complex and it has a lot of overhead, like creating and pushing the import file every time a remote command is executed.

Precommands are just commands being executed beforehand. This allows you to reimplement the import feature in an easy way, by sourcing an existing file. For remote command you may upload a file beforehand.
Besides an easier implementation inside Automatix, it is more clear to the user what is happening, when you use the feature.