### PR TITLE
Convert string bolean values to boolean data types

### DIFF
--- a/automatix/command.py
+++ b/automatix/command.py
@@ -9,6 +9,7 @@ from time import time
 from .colors import italic, yellow
 from .environment import PipelineEnvironment, AttributedDict, AttributedDummyDict
 from .progress_bar import draw_progress_bar
+from .config import convert_boolean_from_input
 
 PERSISTENT_VARS = PVARS = AttributedDict()
 
@@ -434,9 +435,10 @@ class Command:
                 stdout=subprocess.PIPE,
             )
             output = proc.stdout.decode(self.env.config["encoding"])
-            self.env.vars[self.assignment_var] = assigned_value = output.rstrip('\r\n')
+            assigned_value = output.rstrip('\r\n')
+            self.env.vars[self.assignment_var] = convert_boolean_from_input(assigned_value)
             hint = ' (trailing newline removed)' if (output.endswith('\n') or output.endswith('\r')) else ''
-            self.env.LOG.info(f'Variable {self.assignment_var} = "{assigned_value}"{hint}')
+            self.env.LOG.info(f'Variable {self.assignment_var} = "{self.env.vars[self.assignment_var]}"{hint}')
         else:
             proc = subprocess.run(
                 cmd,

--- a/automatix/config.py
+++ b/automatix/config.py
@@ -166,7 +166,11 @@ def _overwrite(script: dict, key: str, data: list[str]):
     script.setdefault(key, {})
     for item in data:
         k, v = item.split('=')
-        script[key][k] = convert_boolean_from_input(v)
+        # Only convert booleans in vars, not in systems or secrets
+        if key == 'vars':
+            script[key][k] = convert_boolean_from_input(v)
+        else:
+            script[key][k] = v
 
 
 def _tupelize(string) -> tuple:

--- a/automatix/config.py
+++ b/automatix/config.py
@@ -166,7 +166,7 @@ def _overwrite(script: dict, key: str, data: list[str]):
     script.setdefault(key, {})
     for item in data:
         k, v = item.split('=')
-        script[key][k] = v
+        script[key][k] = convert_boolean_from_input(v)
 
 
 def _tupelize(string) -> tuple:

--- a/automatix/config.py
+++ b/automatix/config.py
@@ -375,8 +375,12 @@ def update_script_from_row(row: dict, script: dict, index: int):
         key_type, key_name = key.split(':')
         assert key_type in SCRIPT_FIELDS.keys(), \
             f'First row in CSV: Field name is \'{key_type}\', but has to be one of {list(SCRIPT_FIELDS.keys())}.'
-        script[key_type][key_name] = value
+        script[key_type][key_name] = convert_boolean_from_input(value=value)
 
+def convert_boolean_from_input(value: str) -> bool | str: #Convert "true"/"false" strings to boolean, leave everything else as is.
+    if isinstance(value, str) and value.lower() in ('false', 'true'):
+        return value.lower() == 'true'
+    return value
 
 class UnknownSecretTypeException(Exception):
     pass


### PR DESCRIPTION
When variables are read from a csv file, the values are read as strings.   When variables are read from a CSV file, the values are read as strings. This may cause unexpected behavior because any non-empty string is "True" in Python.

Example:
```
x = "False"
if x is True:
    print(x)
```
This PR converts string values "true" and "false" (case-insensitive) to actual booleans when reading from CSV, so that they behave as expected in conditions.
